### PR TITLE
Fix slitaz.sh to work with Slitaz 4.0

### DIFF
--- a/plugins/slitaz.sh
+++ b/plugins/slitaz.sh
@@ -32,7 +32,10 @@ elif [ $1 = copy ];then
 		mcdmount slitaz
 		mkdir -p "${WORK}"/boot/slitaz
 		cp "${MNT}"/slitaz/boot/bzImage "${WORK}"/boot/slitaz/bzImage #Kernel
-		cp "${MNT}"/slitaz/boot/rootfs.gz "${WORK}"/boot/slitaz/rootfs.gz #Root filesystem
+		cp "${MNT}"/slitaz/boot/rootfs1.gz "${WORK}"/boot/slitaz/rootfs1.gz #Root filesystem
+		cp "${MNT}"/slitaz/boot/rootfs2.gz "${WORK}"/boot/slitaz/rootfs2.gz #Root filesystem
+		cp "${MNT}"/slitaz/boot/rootfs3.gz "${WORK}"/boot/slitaz/rootfs3.gz #Root filesystem
+		cp "${MNT}"/slitaz/boot/rootfs4.gz "${WORK}"/boot/slitaz/rootfs4.gz #Root filesystem
 		umcdmount slitaz
 	fi
 elif [ $1 = writecfg ];then
@@ -41,7 +44,7 @@ cat >> "${WORK}"/boot/isolinux/isolinux.cfg << "EOF"
 label slitaz
 	menu label ^SliTaz GNU/Linux
 	kernel /boot/slitaz/bzImage
-	append initrd=/boot/slitaz/rootfs.gz rw root=/dev/null vga=normal
+	append initrd=/boot/slitaz/rootfs4.gz,/boot/slitaz/rootfs3.gz,/boot/slitaz/rootfs2.gz,/boot/slitaz/rootfs1.gz rw root=/dev/null vga=normal autologin
 EOF
 fi
 else


### PR DESCRIPTION
I noticed there are 4 rootfs files in Slitaz 4.0 RC2. This makes the new version work with MultiCD, but it breaks the compatibility with Slitaz 3.0 (I don't know if you try to keep compatibility with older versions) so you may want to pull this only when Slitaz 4.0 is released, rather than now.
