### PR TITLE
Ubuntu alterations:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iso
 *.tar.gz
 **/backup/**
+**/build/**
 memtest
 memtestver

--- a/multicd.sh
+++ b/multicd.sh
@@ -9,7 +9,7 @@ export MCDDIR=$(cd "$(dirname "$0")" && pwd)
 PATH=$PATH:$MCDDIR:$MCDDIR/plugins
 . functions.sh
 
-MCDVERSION="20170427"
+MCDVERSION="20170608"
 #multicd.sh April 27, 2017
 #Copyright (c) 2017 Isaac Schemm
 #
@@ -661,7 +661,10 @@ if [ ! -f "${TAGS}"/win9x ];then
 	EXTRAARGS="$EXTRAARGS -iso-level 4" #To ensure that Windows 9x installation CDs boot properly
 fi
 echo "Building CD image..."
-$GENERATOR -o ""${OUTPUT}"" \
+if [ ! -d "build" ];then
+	mkdir build
+fi
+$GENERATOR -o "./build/"${OUTPUT}"" \
 -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
 -no-emul-boot -boot-load-size 4 -boot-info-table \
 -r -J $EXTRAARGS \
@@ -687,12 +690,12 @@ ISOHYBRID="${TAGS}/isohybrid"
 }
 if [ -f "${TAGS}/isohybrid" ];then
 	echo "Running isohybrid..."
-	"${TAGS}/isohybrid" ""${OUTPUT}"" 2> /dev/null || echo "isohybrid gave an error status of $?. The ISO might not work on a flash drive."
+	"${TAGS}/isohybrid" "./build/"${OUTPUT}"" 2> /dev/null || echo "isohybrid gave an error status of $?. The ISO might not work on a flash drive."
 	rm "${TAGS}"/isohybrid
 fi
 
 if [ $(whoami) == "root" ];then
-	chmod 666 ""${OUTPUT}""
+	chmod -R 666 "./build"
 fi
 rm -r "${TAGS}" "${MNT}"
 
@@ -709,11 +712,11 @@ if $TESTISO;then
 		RAM_TO_USE=128
 	fi
 	if which qemu-system-x86_64 &> /dev/null;then
-		qemu-system-x86_64 -m $RAM_TO_USE -cdrom ""${OUTPUT}""&
+		qemu-system-x86_64 -m $RAM_TO_USE -cdrom "./build/"${OUTPUT}""&
 	elif which qemu &> /dev/null;then
-		qemu -m $RAM_TO_USE -cdrom ""${OUTPUT}""&
+		qemu -m $RAM_TO_USE -cdrom "./build/"${OUTPUT}""&
 	else
-		echo "Cannot test "${OUTPUT}" in a VM. Please install qemu or qemu-system-x86_64."
+		echo "Cannot test ./build/"${OUTPUT}" in a VM. Please install qemu or qemu-system-x86_64."
 	fi
 fi
 

--- a/plugins/ubuntu-alternate.sh
+++ b/plugins/ubuntu-alternate.sh
@@ -2,7 +2,7 @@
 set -e
 . "${MCDDIR}"/functions.sh
 #Ubuntu alternate install CD plugin for multicd.sh
-#version 20121113
+#version 20170608
 #Copyright (c) 2012 Isaac Schemm
 #
 #Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,8 +32,6 @@ if [ $1 = links ];then
 	echo "xubuntu-*-alternate-amd64.iso ubuntu-alternate.iso Xubuntu_alternate_installer_(64-bit)"
 	echo "lubuntu-*-alternate-i386.iso ubuntu-alternate.iso Lubuntu_alternate_installer_(32-bit)"
 	echo "lubuntu-*-alternate-amd64.iso ubuntu-alternate.iso Lubuntu_alternate_installer_(64-bit)"
-	echo "ubuntu-*-server-i386.iso ubuntu-alternate.iso Ubuntu_server_(32-bit)"
-	echo "ubuntu-*-server-amd64.iso ubuntu-alternate.iso Ubuntu_server_(64-bit)"
 elif [ $1 = scan ];then
 	if [ -f ubuntu-alternate.iso ];then
 		echo "Ubuntu alternate installer"

--- a/plugins/ubuntu.sh
+++ b/plugins/ubuntu.sh
@@ -2,7 +2,7 @@
 set -e
 . "${MCDDIR}"/functions.sh
 #Ubuntu plugin for multicd.sh
-#version 20121113
+#version 20170608
 #Copyright (c) 2012 Isaac Schemm
 #
 #Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -54,16 +54,39 @@ getUbuntuName () {
 #END FUNCTIONS#
 
 if [ $1 = links ];then
-	echo "ubuntu-*-desktop-i386.iso i386.ubuntu.iso Ubuntu_(32-bit)_*"
-	echo "ubuntu-*-desktop-amd64.iso amd64.ubuntu.iso Ubuntu_(64-bit)_*"
-	echo "kubuntu-*-desktop-i386.iso i386.k.ubuntu.iso Kubuntu_(32-bit)_*"
-	echo "kubuntu-*-desktop-amd64.iso amd64.k.ubuntu.iso Kubuntu_(64-bit)_*"
-	echo "xubuntu-*-desktop-i386.iso i386.x.ubuntu.iso Xubuntu_(32-bit)_*"
-	echo "xubuntu-*-desktop-amd64.iso amd64.x.ubuntu.iso Xubuntu_(64-bit)_*"
-	echo "edubuntu-*-dvd-i386.iso i386.x.ubuntu.iso Edubuntu_(32-bit)_*"
-	echo "edubuntu-*-dvd-amd64.iso amd64.x.ubuntu.iso Edubuntu_(64-bit)_*"
-	echo "lubuntu-*-desktop-i386.iso i386.l.ubuntu.iso Lubuntu_(32-bit)_*"
-	echo "lubuntu-*-desktop-amd64.iso amd64.l.ubuntu.iso Lubuntu_(64-bit)_*"
+	for i in *ubuntu*.iso; do
+		# stheno - This processes the iso name into usable chunks for other purposes.
+		# This is key in the start for allowing multiple Ubuntu flavors.
+		BASENAME=$(echo $i|sed -e 's/\.iso//g')
+		TYPETEMP=`echo $BASENAME | sed 's/ubuntu.*//g'`
+		VERSIONPRE=`echo $BASENAME | sed 's/.*ubuntu-//g'`
+		VERSIONPOST=`echo $VERSIONPRE | sed 's/-.*//g'`
+		ARCHPRE=`echo $BASENAME | sed "s/.*ubuntu-"${VERSIONPOST}"-//g"`
+		ARCHPOST=`echo $ARCHPRE | sed 's/.*-//g'`
+		PLATPRE=`echo $BASENAME | sed "s/.*ubuntu-"${VERSIONPOST}"-//g"`
+		PLATPOST=`echo $PLATPRE | sed 's/-.*//g'`
+		if [ "${TYPETEMP}" ];then
+			TYPE="${TYPETEMP}."
+			TYPELABEL=$(echo $TYPETEMP | sed 's/./\U&/')u
+		else
+			TYPE=""
+			TYPELABEL="U"
+		fi
+		if [ "${ARCHPOST}" = "i386" ];then
+			ARCHLABEL="(32-bit)"
+		elif [ "${ARCHPOST}" = "amd64" ];then
+			ARCHLABEL="(64-bit)"
+		else
+			ARCHLABEL=""
+		fi
+		# stheno - writes temp file to parse new menu title.
+		echo "${TYPELABEL}buntu_${VERSIONPOST}_${PLATPOST}_${ARCHLABEL}" > "${VERSIONPOST}.${ARCHPOST}.${PLATPOST}".ubuntu.title
+		# stheno - This covers ALL links available on discovered files.
+		# No need to write entries that do not exist and be bound to only them.
+		# This facilitates multiple iso files of similar flavor but different versions or arch.
+		echo "${TYPETEMP}ubuntu-${VERSIONPOST}-${PLATPOST}-${ARCHPOST}.iso ${VERSIONPOST}.${ARCHPOST}.${PLATPOST}.${TYPE}ubuntu.iso ${TYPELABEL}buntu_${VERSIONPOST}_${PLATPOST}_${ARCHLABEL}"
+	done
+
 elif [ $1 = scan ];then
 	if $(ubuntuExists);then
 		for i in *.ubuntu.iso; do
@@ -77,62 +100,151 @@ elif [ $1 = copy ];then
 			echo "Copying $(getUbuntuName)..."
 			BASENAME=$(echo $i|sed -e 's/\.iso//g')
 			if [ ! -z "$BASENAME" ] && [ -f $BASENAME.iso ];then
-				mcdmount $BASENAME
-				mkdir -p "${WORK}"/boot/$BASENAME
-				if [ -d "${MNT}"/$BASENAME/casper ];then
-					mcdcp -R "${MNT}"/$BASENAME/casper/* "${WORK}"/boot/$BASENAME/ #Live system
-				#elif [ -d "${MNT}/$BASENAME/live" ];then
-				#	mcdcp -R "${MNT}"/$BASENAME/live/* "${WORK}"/boot/$BASENAME/ #Debian live (for Linux Mint Debian)
-				else
-					echo "Could not find a \"casper\" folder in "${MNT}"/$BASENAME."
-					return 1
-				fi
-				if [ -d "${MNT}"/$BASENAME/preseed ];then
-					cp -R "${MNT}"/$BASENAME/preseed "${WORK}"/boot/$BASENAME
-				fi
-				# Fix the isolinux.cfg
-				if [ -f "${MNT}"/$BASENAME/isolinux/text.cfg ];then
-					UBUCFG=text.cfg
-				elif [ -f "${MNT}"/$BASENAME/isolinux/txt.cfg ];then
-					UBUCFG=txt.cfg
-				else
-					UBUCFG=isolinux.cfg #For custom-made live CDs like Weaknet and Zorin
-				fi
-				cp "${MNT}"/$BASENAME/isolinux/splash.* \
-				"${MNT}"/$BASENAME/isolinux/bg_redo.png \
-				"${WORK}"/boot/$BASENAME/ 2> /dev/null || true #Splash screen - only if the filename is splash.something or bg_redo.png
-				cp "${MNT}"/$BASENAME/isolinux/$UBUCFG "${WORK}"/boot/$BASENAME/$BASENAME.cfg
-				echo "label back
-				menu label Back to main menu
-				com32 menu.c32
-				append /boot/isolinux/isolinux.cfg
-				" >> "${WORK}"/boot/$BASENAME/$BASENAME.cfg
-				sed -i "s@menu background @menu background /boot/$BASENAME/@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #If it uses a splash screen, update the .cfg to show the new location
-				sed -i "s@MENU BACKGROUND @MENU BACKGROUND /boot/$BASENAME/@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #uppercase
-				sed -i "s@default live@default menu.c32@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Show menu instead of boot: prompt
-				sed -i "s@file=/cdrom/preseed/@file=/cdrom/boot/$BASENAME/preseed/@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Preseed folder moved - not sure if ubiquity uses this
+				# stheno - Look for what types of Ubuntu installer iso we have.
+				# Then build accordingly, final stage in allowing multiple flavors.
+				case "$BASENAME" in
+					*desktop*)
+						mcdmount $BASENAME
+						mkdir -p "${WORK}"/boot/$BASENAME
+						if [ -d "${MNT}"/$BASENAME/casper ];then
+							mcdcp -R "${MNT}"/$BASENAME/casper/* "${WORK}"/boot/$BASENAME/ #Live system
+						#elif [ -d "${MNT}/$BASENAME/live" ];then
+						#	mcdcp -R "${MNT}"/$BASENAME/live/* "${WORK}"/boot/$BASENAME/ #Debian live (for Linux Mint Debian)
+						else
+							echo "Could not find a \"casper\" folder in "${MNT}"/$BASENAME."
+							return 1
+						fi
+						if [ -d "${MNT}"/$BASENAME/preseed ];then
+							cp -R "${MNT}"/$BASENAME/preseed "${WORK}"/boot/$BASENAME
+						fi
+						# Fix the isolinux.cfg
+						if [ -f "${MNT}"/$BASENAME/isolinux/text.cfg ];then
+							UBUCFG=text.cfg
+						elif [ -f "${MNT}"/$BASENAME/isolinux/txt.cfg ];then
+							UBUCFG=txt.cfg
+						else
+							UBUCFG=isolinux.cfg #For custom-made live CDs like Weaknet and Zorin
+						fi
+						cp "${MNT}"/$BASENAME/isolinux/splash.* \
+						"${MNT}"/$BASENAME/isolinux/bg_redo.png \
+						"${WORK}"/boot/$BASENAME/ 2> /dev/null || true #Splash screen - only if the filename is splash.something or bg_redo.png
+						cp "${MNT}"/$BASENAME/isolinux/$UBUCFG "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						
+						MENUTITLETEMP=`cat $BASENAME.title`
+						rm $BASENAME.title
+						MENUTITLE=$(echo "$MENUTITLETEMP" | sed 's/_/ /g')
+						
+						CFGFILE=`cat "${WORK}""/boot/$BASENAME/$BASENAME".cfg`
 
-				#Remove reference to previous live media path
-				sed -i "s^live-media-path=[^ ]*^^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						EDITS=$(echo "$CFGFILE" | \
+							sed '/default live/a menu title '"$MENUTITLE" | \
+							sed 's/default live/default menu.c32/g' | \
+							sed 's/\/casper\//\/boot\/'"$BASENAME"'\//g' | \
+							sed 's/\/cdrom\//\/boot\/'"$BASENAME"'\//g' | \
+							sed 's/casper initrd/casper live-media-path=\/boot\/'"$BASENAME"' ignore_uuid initrd/g' | \
+							sed 's/ubiquity initrd/ubiquity live-media-path=\/boot\/'"$BASENAME"' ignore_uuid initrd/g' | \
+							sed 's/check initrd/check live-media-path=\/boot\/'"$BASENAME"' ignore_uuid initrd/g' | \
+							sed 's/\/install\//\/boot\/'"$BASENAME"'\//g' | \
+							sed '$ a label back' | \
+							sed '$ a menu label Back to main menu' | \
+							sed '$ a \\tcom32 menu.c32' | \
+							sed 's/menu title/\\tmenu title/g' | \
+							sed 's/menu label/\\tmenu label/g' | \
+							sed 's/kernel /\\tkernel /g' | \
+							sed 's/KERNEL /\\tKERNEL /g' | \
+							sed 's/localboot/\\tlocalboot/g' | \
+							sed 's/append  /\\tappend /g' | \
+							sed '$ a \\tappend /boot/isolinux/isolinux.cfg'
+						)
+						echo "$EDITS" > "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						
+						# stheno - I left the in but commented, not sure if there are use cases still?
+						#sed -i "s@menu background @menu background /boot/$BASENAME/@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #If it uses a splash screen, update the .cfg to show the new location
+						#sed -i "s@MENU BACKGROUND @MENU BACKGROUND /boot/$BASENAME/@g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #uppercase
+						
+						##Remove reference to previous live media path
+						#sed -i "s^live-media-path=[^ ]*^^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
 
-				sed -i "s^initrd=/casper/^live-media-path=/boot/$BASENAME ignore_uuid initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Initrd moved, ignore_uuid added
-				sed -i "s^kernel /casper/^kernel /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Kernel moved
-				sed -i "s^KERNEL /casper/^KERNEL /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #For uppercase KERNEL
+						##Equivalents for Mint Debian
+						##sed -i "s^initrd=/live/^live-media-path=/boot/$BASENAME ignore_uuid initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						##sed -i "s^kernel /live/^kernel /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						##sed -i "s^KERNEL /live/^KERNEL /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
 
-				#Equivalents for Mint Debian
-				#sed -i "s^initrd=/live/^live-media-path=/boot/$BASENAME ignore_uuid initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
-				#sed -i "s^kernel /live/^kernel /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
-				#sed -i "s^KERNEL /live/^KERNEL /boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						# stheno - Duplicated these in both server and desktop. Don't want any writing if failure to find matching case.
+						if [ -f "${TAGS}"/lang ];then
+							echo added lang
+							sed -i "s^initrd=/boot/$BASENAME/^debian-installer/language=$(cat "${TAGS}"/lang) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
+						fi
+						if [ -f "${TAGS}"/country ];then
+							echo added country
+							sed -i "s^initrd=/boot/$BASENAME/^console-setup/layoutcode?=$(cat "${TAGS}"/country) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
+						fi
+						
+						umcdmount $BASENAME
+					;;
 
-				if [ -f "${TAGS}"/lang ];then
-					echo added lang
-					sed -i "s^initrd=/boot/$BASENAME/^debian-installer/language=$(cat "${TAGS}"/lang) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
-				fi
-				if [ -f "${TAGS}"/country ];then
-					echo added country
-					sed -i "s^initrd=/boot/$BASENAME/^console-setup/layoutcode?=$(cat "${TAGS}"/country) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
-				fi
-				umcdmount $BASENAME
+					*server*)
+						mcdmount $BASENAME
+						mkdir -p "${WORK}"/boot/$BASENAME
+						if [ -d "${MNT}"/$BASENAME/install ];then
+							mcdcp -R "${MNT}"/$BASENAME/install/* "${WORK}"/boot/$BASENAME/ #Live system
+						else
+							echo "Could not find a \"install\" folder in "${MNT}"/$BASENAME."
+							return 1
+						fi
+						if [ -d "${MNT}"/$BASENAME/preseed ];then
+							cp -R "${MNT}"/$BASENAME/preseed "${WORK}"/boot/$BASENAME
+						fi
+						# Fix the isolinux.cfg
+						if [ -f "${MNT}"/$BASENAME/isolinux/text.cfg ];then
+							UBUCFG=text.cfg
+						elif [ -f "${MNT}"/$BASENAME/isolinux/txt.cfg ];then
+							UBUCFG=txt.cfg
+						else
+							UBUCFG=isolinux.cfg
+						fi
+						cp "${MNT}"/$BASENAME/isolinux/splash.* \
+						"${MNT}"/$BASENAME/isolinux/bg_redo.png \
+						"${WORK}"/boot/$BASENAME/ 2> /dev/null || true #Splash screen - only if the filename is splash.something or bg_redo.png
+						cp "${MNT}"/$BASENAME/isolinux/$UBUCFG "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+						
+						MENUTITLETEMP=`cat $BASENAME.title`
+						rm $BASENAME.title
+						MENUTITLE=$(echo "$MENUTITLETEMP" | sed 's/_/ /g')
+						
+						CFGFILE=`cat "${WORK}""/boot/$BASENAME/$BASENAME".cfg`
+						
+						EDITS=$(echo "$CFGFILE" | \
+								sed '/default install/a menu title '"$MENUTITLE" | \
+								sed 's/\/install\//\/boot\/'"$BASENAME"'\//g' | \
+								sed 's/\/cdrom\//\/boot\/'"$BASENAME"'\//g' | \
+								sed '$ a label back' | \
+								sed '$ a menu label Back to main menu' | \
+								sed '$ a com32 menu.c32' | \
+								sed '$ a \\tappend /boot/isolinux/isolinux.cfg' | \
+								sed 's/menu title/\\tmenu title/g' | \
+								sed 's/menu label/\\tmenu label/g' | \
+								sed 's/kernel /\\tkernel /g' | \
+								sed 's/com32/\\tcom32/g' | \
+								sed 's/localboot/\\tlocalboot/g' | \
+								sed 's/append  /\\tappend/g' | \
+								sed 's/appendfile/append file/g'
+						)
+						echo "$EDITS" > "${WORK}"/boot/$BASENAME/$BASENAME.cfg
+												
+						# stheno - Duplicated these in both server and desktop. Don't want any writing if failure to find matching case.
+						if [ -f "${TAGS}"/lang ];then
+							echo added lang
+							sed -i "s^initrd=/boot/$BASENAME/^debian-installer/language=$(cat "${TAGS}"/lang) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
+						fi
+						if [ -f "${TAGS}"/country ];then
+							echo added country
+							sed -i "s^initrd=/boot/$BASENAME/^console-setup/layoutcode?=$(cat "${TAGS}"/country) initrd=/boot/$BASENAME/^g" "${WORK}"/boot/$BASENAME/$BASENAME.cfg #Add language codes to cmdline
+						fi
+						
+						umcdmount $BASENAME
+					;;
+				esac
 			else
 				echo "$0: \"$BASENAME\" is empty or not an ISO"
 				exit 1


### PR DESCRIPTION
Added multiple arch and version support on a single iso build.
This should nearly eliminate the need for alternate.
This likely closes issues 23 and 54

Added a menu header title to Ubuntu sub menus
Fixed a few menu items by re-factoring the generation of the menus entirely.
Moved and duplicated language and country to inside the case check for types of install.
This avoids a write attempt on a menu if a type is not detected.

Added a "build" directory so the built iso does not show up in the scan for iso inclusion (thereby breaking it).
Bumped the version up for both main and Ubuntu since both were altered.

Tested against these iso files:
ubuntu-12.04.4-server-amd64.iso
ubuntu-14.04-desktop-amd64.iso
ubuntu-14.04-server-amd64.iso
ubuntu-14.04.4-desktop-i386.iso
ubuntu-14.04.5-server-i386.iso
ubuntu-16.10-desktop-amd64.iso
ubuntu-16.10-server-amd64.iso