### PR TITLE
Fixed Arch directory bug and added new Fossa pup to the list

### DIFF
--- a/plugins/arch.sh
+++ b/plugins/arch.sh
@@ -38,6 +38,7 @@ elif [ $1 = copy ];then
 		echo "Copying Arch Linux..."
 		mcdmount arch
 		mcdcp -r -T "${MNT}"/arch/arch "${WORK}"/arch
+		mcdcp -r "${MNT}"/arch/syslinux "${WORK}"/arch/boot/
 		umcdmount arch
 	fi
 elif [ $1 = writecfg ];then

--- a/plugins/puppy.sh
+++ b/plugins/puppy.sh
@@ -36,6 +36,7 @@ if [ $1 = links ];then
 	echo "racy-*.iso racy.puppy.iso none"
 	echo "slacko-*.iso slacko.puppy.iso Slacko_*"
 	echo "tahr-*.iso tahr.puppy.iso Tahrpup_*"
+	echo "fossa-*.iso fossa.puppy.iso Fossapup_*"
 elif [ $1 = scan ];then
 	if $(puppyExists);then for i in *.puppy.iso;do
 		echo "Puppy Linux"


### PR DESCRIPTION
### Bug
1. New versions of Arch Linux iso will not work from the existing code as the directory of the `syslinux` folder has been moved out from `/arch/boot/syslinux` to simply `/arch/syslinux`.
**Fixed**

### Updates
1. New Puppy-v9.5 named FossaPup64 has been released which was not added to the list.
**Added**